### PR TITLE
Switch from snafu to thiserror for Error derivations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 libc = "0.2"
-snafu = "0.6"
+thiserror = "1.0"
 
 [dev-dependencies]
 chrono = "0.4"

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -56,6 +56,7 @@ impl Ax25RawSocket {
     }
 
     /// Block to receive an incoming AX.25 frame from any interface
+    #[allow(unused_variables)]
     pub(crate) fn receive_frame(&self, ifindex: i32) -> io::Result<Vec<u8>> {
         #[cfg(target_os = "linux")]
         {
@@ -162,7 +163,10 @@ mod sys {
         }
     }
 
-    pub(crate) fn socket_receive_frame(socket: &Ax25RawSocket, ifindex: i32) -> io::Result<Vec<u8>> {
+    pub(crate) fn socket_receive_frame(
+        socket: &Ax25RawSocket,
+        ifindex: i32,
+    ) -> io::Result<Vec<u8>> {
         let mut buf: [u8; 1024] = [0; 1024];
         let mut addr_struct: sockaddr_ll = unsafe { mem::zeroed() };
         let mut len: usize;


### PR DESCRIPTION
Since I first wrote these errors I've become a fan of the `thiserror`-for-libraries and `anyhow`-for-applications approach to generating `Error` types.

`thiserror` doesn't offer quite as much functionality, particularly the `ensure!` macro, so I've had to be a little more explicit, which I don't mind.