### PR TITLE
Fix clippy errors and improve CI lints

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,10 @@ jobs:
       run: cargo check --all-targets
     - name: Run tests
       run: cargo test
+    - name: Clean
+      run: cargo clean
+    - name: Check formatting
+      run: cargo fmt -- --check
     - name: Clippy
       run: cargo clippy -- -Dwarnings
 
@@ -22,6 +26,9 @@ jobs:
       run: cargo check --all-targets
     - name: Run tests
       run: cargo test
+    - name: Clean
+      run: cargo clean
+    - name: Check formatting
+      run: cargo fmt -- --check
     - name: Clippy
       run: cargo clippy -- -Dwarnings
-

--- a/src/tnc.rs
+++ b/src/tnc.rs
@@ -97,20 +97,20 @@ impl FromStr for TncAddress {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if !s.starts_with("tnc:") {
-            Err(ParseError::NoTncPrefix {
+            return Err(ParseError::NoTncPrefix {
                 string: s.to_string(),
-            })?;
+            });
         }
         let components: Vec<&str> = s.split(':').collect();
         let len = components.len();
         Ok(match components[1] {
             "tcpkiss" => {
                 if len != 4 {
-                    Err(ParseError::WrongParameterCount {
+                    return Err(ParseError::WrongParameterCount {
                         tnc_type: components[1].to_string(),
                         expected: 2usize,
                         actual: len - 2,
-                    })?;
+                    });
                 }
                 TncAddress {
                     config: ConnectConfig::TcpKiss(TcpKissConfig {
@@ -124,11 +124,11 @@ impl FromStr for TncAddress {
             }
             "linuxif" => {
                 if len != 3 {
-                    Err(ParseError::WrongParameterCount {
+                    return Err(ParseError::WrongParameterCount {
                         tnc_type: components[1].to_string(),
                         expected: 1usize,
                         actual: len - 2,
-                    })?;
+                    });
                 }
                 TncAddress {
                     config: ConnectConfig::LinuxIf(LinuxIfConfig {
@@ -136,9 +136,11 @@ impl FromStr for TncAddress {
                     }),
                 }
             }
-            unknown => Err(ParseError::UnknownType {
-                tnc_type: unknown.to_string(),
-            })?,
+            unknown => {
+                return Err(ParseError::UnknownType {
+                    tnc_type: unknown.to_string(),
+                })
+            }
         })
     }
 }
@@ -200,9 +202,11 @@ impl LinuxIfTnc {
             .find(|nd| nd.name.to_uppercase() == config.callsign.to_uppercase())
         {
             Some(nd) => nd.ifindex,
-            None => Err(TncError::InterfaceNotFound {
-                callsign: config.callsign.clone(),
-            })?,
+            None => {
+                return Err(TncError::InterfaceNotFound {
+                    callsign: config.callsign.clone(),
+                })
+            }
         };
         Ok(Self {
             socket: Arc::new(socket),


### PR DESCRIPTION
I learnt today that [Clippy doesn't report error/warnings after cargo check](https://github.com/rust-lang/rust-clippy/issues/4612), which meant that the GitHub Action I had defined was ineffective. I've introduced a `cargo clean` step to ensure the build will fail if we don't keep clippy happy.

In my most recent PR I standardised on the form `Err(...)?;` but clippy [doesn't recommend this](https://rust-lang.github.io/rust-clippy/master/index.html#try_err) so I've gone back to the `return` form in all cases.

In addition, I'm adding a check to make sure that code is formatted according to `rustfmt`. In my experience this is useful to avoid needless merge conflicts (and arguments), and we can rely on the "skip" macro if there's anything that really deserves to have its whitespace left intact.