### PR TITLE
Implement support for serial port KISS TNCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ The crate `ax25_tnc` provides:
 Most developers will want to focus on `tnc::TncAddress` and `tnc::Tnc`.
 1. Generate or ask the user to supply an address string. This takes the form:  
    `tnc:tcpkiss:192.168.0.1:8001` or  
-   `tnc:linuxif:vk7ntk-2`
+   `tnc:linuxif:vk7ntk-2` or  
+   `tnc:serialkiss:/dev/ttyUSB0:9600`
 2. Parse this to an address: `let addr = string.parse::<TncAddress>()?;`
 3. Attempt to open the TNC: `let tnc = Tnc::open(&addr)?;`
 4. Use `send_frame()` and `receive_frame()` to communicate on the radio.
@@ -56,6 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("where tnc-address is something like");
         println!("  tnc:linuxif:vk7ntk-2");
         println!("  tnc:tcpkiss:192.168.0.1:8001");
+        println!("  tnc:serialkiss:/dev/ttyUSB0:9600");
         std::process::exit(1);
     }
 
@@ -89,7 +91,6 @@ is available through its fields which are not printed here.
 
 Planned features:
 
-* Support for serial KISS TNCs (physical, TNC-Pi, Dire Wolf pseudo-tty)
 * Paclen management
 * More convenient send/receive interfaces for messing around with UI frames
 * Direct use of linux axports interfaces without `kissattach`

--- a/ax25_tnc/Cargo.toml
+++ b/ax25_tnc/Cargo.toml
@@ -14,6 +14,10 @@ readme = "../README.md"
 ax25 = "0.3"
 #ax25 = { path = "../ax25" }
 libc = "0.2"
+serialport = { version = "4.9.0", optional = true }
 
 [dev-dependencies]
 time = { version = "0.3.9", features = ["local-offset"] }
+
+[features]
+serial = ["dep:serialport"]

--- a/ax25_tnc/examples/listen.rs
+++ b/ax25_tnc/examples/listen.rs
@@ -9,6 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("where tnc-address is something like");
         println!("  tnc:linuxif:vk7ntk-2");
         println!("  tnc:tcpkiss:192.168.0.1:8001");
+        println!("  tnc:serialkiss:/dev/ttyUSB0:9600");
         std::process::exit(1);
     }
 

--- a/ax25_tnc/src/kiss.rs
+++ b/ax25_tnc/src/kiss.rs
@@ -6,6 +6,15 @@ use std::net::ToSocketAddrs;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
+#[cfg(feature = "serial")]
+use serialport::{self, SerialPort};
+
+#[cfg(feature = "serial")]
+use std::time::Duration;
+
+#[cfg(not(feature = "serial"))]
+use std::io::{Error, ErrorKind};
+
 const FEND: u8 = 0xC0;
 const FESC: u8 = 0xDB;
 const TFEND: u8 = 0xDC;
@@ -74,6 +83,112 @@ impl TcpKissInterface {
 }
 
 impl Drop for TcpKissInterface {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+pub(crate) struct SerialKissInterface {
+    // Interior mutability is desirable so that we can clone the TNC and have
+    // different threads sending and receiving concurrently.
+    #[cfg(feature = "serial")]
+    tx_stream: Mutex<Box<dyn SerialPort>>,
+    #[cfg(feature = "serial")]
+    rx_stream: Mutex<Box<dyn SerialPort>>,
+    #[cfg(feature = "serial")]
+    buffer: Mutex<Vec<u8>>,
+    is_shutdown: AtomicBool,
+}
+
+impl SerialKissInterface {
+    #[allow(unused_variables)]
+    pub(crate) fn new(device: &str, baud: u32) -> io::Result<SerialKissInterface> {
+        #[cfg(feature = "serial")]
+        {
+            let tx_stream = serialport::new(device, baud)
+                .timeout(Duration::MAX)
+                .open()?;
+            let rx_stream = tx_stream.try_clone()?;
+            Ok(SerialKissInterface {
+                tx_stream: Mutex::new(tx_stream),
+                rx_stream: Mutex::new(rx_stream),
+                buffer: Mutex::new(Vec::new()),
+                is_shutdown: AtomicBool::new(false),
+            })
+        }
+
+        #[cfg(not(feature = "serial"))]
+        {
+            Err(Error::new(
+                ErrorKind::Unsupported,
+                "Serial port devices are not supported.",
+            ))
+        }
+    }
+
+    pub(crate) fn receive_frame(&self) -> io::Result<Vec<u8>> {
+        #[cfg(feature = "serial")]
+        {
+            loop {
+                {
+                    let mut buffer = self.buffer.lock().unwrap();
+                    if let Some(frame) = make_frame_from_buffer(&mut buffer) {
+                        return Ok(frame);
+                    }
+                }
+                let mut buf = vec![0u8; 1024];
+                let n_bytes = {
+                    let mut rx_stream = self.rx_stream.lock().unwrap();
+                    rx_stream.read(&mut buf)?
+                };
+                {
+                    let mut buffer = self.buffer.lock().unwrap();
+                    buffer.extend(buf.iter().take(n_bytes));
+                }
+            }
+        }
+
+        #[cfg(not(feature = "serial"))]
+        {
+            Err(Error::new(
+                ErrorKind::NotConnected,
+                "Serial port devices are not supported.",
+            ))
+        }
+    }
+
+    #[allow(unused_variables)]
+    pub(crate) fn send_frame(&self, frame: &[u8]) -> io::Result<()> {
+        #[cfg(feature = "serial")]
+        {
+            let mut tx_stream = self.tx_stream.lock().unwrap();
+            // 0x00 is the KISS command byte, which is two nybbles
+            // port = 0
+            // command = 0 (all following bytes are a data frame to transmit)
+            tx_stream.write_all(&[FEND, 0x00])?;
+            tx_stream.write_all(frame)?;
+            tx_stream.write_all(&[FEND])?;
+            tx_stream.flush()?;
+            Ok(())
+        }
+
+        #[cfg(not(feature = "serial"))]
+        {
+            Err(Error::new(
+                ErrorKind::NotConnected,
+                "Serial port devices are not supported.",
+            ))
+        }
+    }
+
+    pub(crate) fn shutdown(&self) {
+        if !self.is_shutdown.load(Ordering::SeqCst) {
+            self.is_shutdown.store(true, Ordering::SeqCst);
+        }
+    }
+}
+
+impl Drop for SerialKissInterface {
     fn drop(&mut self) {
         self.shutdown();
     }

--- a/ax25_tnc/src/linux.rs
+++ b/ax25_tnc/src/linux.rs
@@ -224,10 +224,7 @@ mod sys {
         if req.data.address_family() as i32 != AF_AX25 {
             return None;
         }
-        let hw_addr = match req.data.ax25_address() {
-            Some(addr) => addr,
-            None => return None,
-        };
+        let hw_addr = req.data.ax25_address()?;
 
         if unsafe { ioctl(fd, SIOCGIFINDEX, &mut req) } == -1 {
             return None;

--- a/ax25_tnc/src/tnc.rs
+++ b/ax25_tnc/src/tnc.rs
@@ -13,6 +13,7 @@ use std::thread;
 pub enum TncError {
     OpenTnc { source: std::io::Error },
     InterfaceNotFound { callsign: String },
+    PortNotFound { device: String },
     SendFrame { source: std::io::Error },
     ReceiveFrame { source: std::io::Error },
     ConfigFailed { source: std::io::Error },
@@ -23,6 +24,7 @@ impl Error for TncError {
         match self {
             Self::OpenTnc { source } => Some(source),
             Self::InterfaceNotFound { .. } => None,
+            Self::PortNotFound { .. } => None,
             Self::SendFrame { source } => Some(source),
             Self::ReceiveFrame { source } => Some(source),
             Self::ConfigFailed { source } => Some(source),
@@ -38,6 +40,11 @@ impl fmt::Display for TncError {
                 f,
                 "Interface with specified callsign '{}' does not exist",
                 callsign
+            ),
+            Self::PortNotFound { device } => write!(
+                f,
+                "Specified serial port device '{}' does not exist",
+                device
             ),
             Self::SendFrame { source } => write!(f, "Unable to send frame: {}", source),
             Self::ReceiveFrame { source } => write!(f, "Unable to receive frame: {}", source),
@@ -63,6 +70,10 @@ pub enum ParseError {
         actual: usize,
     },
     InvalidPort {
+        input: String,
+        source: std::num::ParseIntError,
+    },
+    InvalidBaud {
         input: String,
         source: std::num::ParseIntError,
     },
@@ -93,6 +104,11 @@ impl fmt::Display for ParseError {
                 "Supplied port '{}' should be a number from 0 to 65535",
                 input
             ),
+            Self::InvalidBaud { input, .. } => write!(
+                f,
+                "Supplied baud rate '{}' should be a number like 4800 or 9600",
+                input
+            ),
         }
     }
 }
@@ -105,6 +121,16 @@ pub struct TcpKissConfig {
     pub host: String,
     /// Port number
     pub port: u16,
+}
+
+/// Configuration details for a Serial Port KISS TNC. This structure can be created
+/// directly or indirectly by parsing a string into a `TncAddress`.
+#[derive(PartialEq, Debug, Eq)]
+pub struct SerialKissConfig {
+    /// Device name or path for the serial port interface
+    pub device: String,
+    /// Baud rate for the serial port
+    pub baud: u32,
 }
 
 /// Configuration details for a TNC attached as a Linux network interface using
@@ -120,6 +146,7 @@ pub struct LinuxIfConfig {
 pub(crate) enum ConnectConfig {
     TcpKiss(TcpKissConfig),
     LinuxIf(LinuxIfConfig),
+    SerialKiss(SerialKissConfig),
 }
 
 /// A parsed TNC address that can be used to open a `Tnc`.
@@ -140,6 +167,13 @@ impl TncAddress {
     pub fn new_tcpkiss(tcpkiss: TcpKissConfig) -> Self {
         TncAddress {
             config: ConnectConfig::TcpKiss(tcpkiss),
+        }
+    }
+
+    /// Programmatically create a `TncAddress` pointing to a serial port KISS interface.
+    pub fn new_serialkiss(serialkiss: SerialKissConfig) -> Self {
+        TncAddress {
+            config: ConnectConfig::SerialKiss(serialkiss),
         }
     }
 }
@@ -188,6 +222,24 @@ impl FromStr for TncAddress {
                     }),
                 }
             }
+            "serialkiss" => {
+                if len != 4 {
+                    return Err(ParseError::WrongParameterCount {
+                        tnc_type: components[1].to_string(),
+                        expected: 2usize,
+                        actual: len - 2,
+                    });
+                }
+                TncAddress {
+                    config: ConnectConfig::SerialKiss(SerialKissConfig {
+                        device: components[2].to_string(),
+                        baud: components[3].parse().map_err(|e| ParseError::InvalidBaud {
+                            input: components[3].to_string(),
+                            source: e,
+                        })?,
+                    }),
+                }
+            }
             unknown => {
                 return Err(ParseError::UnknownType {
                     tnc_type: unknown.to_string(),
@@ -214,6 +266,7 @@ impl Tnc {
         let imp: Box<dyn TncImpl> = match &address.config {
             ConnectConfig::TcpKiss(config) => Box::new(TcpKissTnc::open(config)?),
             ConnectConfig::LinuxIf(config) => Box::new(LinuxIfTnc::open(config)?),
+            ConnectConfig::SerialKiss(config) => Box::new(SerialKissTnc::open(config)?),
         };
         Ok(Tnc(Arc::new(Mutex::new(TncInner::new(imp)))))
     }
@@ -394,6 +447,51 @@ impl TncImpl for TcpKissTnc {
     }
 }
 
+struct SerialKissTnc {
+    iface: Arc<kiss::SerialKissInterface>,
+}
+
+impl SerialKissTnc {
+    fn open(config: &SerialKissConfig) -> Result<Self, TncError> {
+        Ok(Self {
+            iface: Arc::new(
+                kiss::SerialKissInterface::new(&config.device, config.baud)
+                    .map_err(|e| TncError::OpenTnc { source: e })?,
+            ),
+        })
+    }
+}
+
+impl TncImpl for SerialKissTnc {
+    fn send_frame(&self, frame: &Ax25Frame) -> Result<(), TncError> {
+        self.iface
+            .send_frame(&frame.to_bytes())
+            .map_err(|e| TncError::SendFrame { source: e })
+    }
+
+    fn receive_frame(&self) -> Result<Ax25Frame, TncError> {
+        loop {
+            let bytes = self
+                .iface
+                .receive_frame()
+                .map_err(|e| TncError::ReceiveFrame { source: e })?;
+            if let Ok(parsed) = Ax25Frame::from_bytes(&bytes) {
+                return Ok(parsed);
+            }
+        }
+    }
+
+    fn clone(&self) -> Box<dyn TncImpl> {
+        Box::new(SerialKissTnc {
+            iface: self.iface.clone(),
+        })
+    }
+
+    fn shutdown(&self) {
+        self.iface.shutdown();
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -414,6 +512,15 @@ mod test {
             Ok(TncAddress {
                 config: ConnectConfig::LinuxIf(LinuxIfConfig {
                     callsign: "VK7NTK-2".to_string(),
+                })
+            })
+        );
+        assert_eq!(
+            "tnc:serialkiss:/dev/ttyUSB0:9200".parse::<TncAddress>(),
+            Ok(TncAddress {
+                config: ConnectConfig::SerialKiss(SerialKissConfig {
+                    device: "/dev/ttyUSB0".to_string(),
+                    baud: 9200
                 })
             })
         );
@@ -471,5 +578,25 @@ mod test {
                 _ => false,
             }
         );
+        assert!(match "tnc:serialkiss:".parse::<TncAddress>() {
+            Err(ParseError::WrongParameterCount {
+                tnc_type,
+                expected,
+                actual,
+            }) => {
+                tnc_type == "serialkiss" && expected == 2 && actual == 1
+            }
+            _ => false,
+        });
+        assert!(match "tnc:serialkiss:a:b:c".parse::<TncAddress>() {
+            Err(ParseError::WrongParameterCount {
+                tnc_type,
+                expected,
+                actual,
+            }) => {
+                tnc_type == "serialkiss" && expected == 2 && actual == 3
+            }
+            _ => false,
+        });
     }
 }


### PR DESCRIPTION
(Disclaimer: This is my first time ever working in Rust, and while this appears to work it feels like there's a lot of repeated code and I am not experienced enough with Rust to know how to improve that)

This adds a new TNC implementation for KISS TNC over serial port, relying on the [`serialport-rs`](https://github.com/serialport/serialport-rs) crate to do the heavy lifting. In theory, this should support serial ports on both Linux and Windows, but I was only able to test Linux.

I've gated this behind a `serial` feature so the new dependency is optional.

The address format for serial port KISS TNCs is `tnc:serialkiss:<device path>:<baud rate>`.
* Linux example: `tnc:serialkiss:/dev/ttyUSB0:1200`
* Windows example: `tnc:serialkiss:COM3:9600`